### PR TITLE
Quote param expansion to avoid whitespace issues

### DIFF
--- a/quimby.sh
+++ b/quimby.sh
@@ -80,5 +80,5 @@ then
   cover_letter_flag="--cover-letter"
 fi
 
-git format-patch ${cover_letter_flag} ${PARAMS[@]:2} \
+git format-patch ${cover_letter_flag} "${PARAMS[@]:2}" \
   "${base_branch}..${topic_branch}"


### PR DESCRIPTION
The git-format-patch call fails if an argument contains spaces (e.g.,
--from="My Name <address@example.com>"). Add quotes around the parameter
expansion to fix that.